### PR TITLE
Add call to Hedwig.Robot.handle_connect on :connected callback

### DIFF
--- a/lib/hedwig_irc.ex
+++ b/lib/hedwig_irc.ex
@@ -36,11 +36,12 @@ defmodule Hedwig.Adapters.IRC do
     {:noreply, state}
   end
 
-  def handle_info({:connected, server, port}, state = {_robot, opts, client}) do
+  def handle_info({:connected, server, port}, state = {robot, opts, client}) do
     Logger.info "Connected to #{server}:#{port}"
     pass = Keyword.fetch!(opts, :password)
     name = Keyword.fetch!(opts, :name)
     ExIrc.Client.logon client, pass, name, name, name
+    :ok = Hedwig.Robot.handle_connect(robot)
     {:noreply, state}
   end
 


### PR DESCRIPTION
Otherwise the `handle_connect/1` function in the robot module never gets called and the bot won't be registered by it's name (when using the default robot module setup).