### PR TITLE
Add :disconnected message handler

### DIFF
--- a/lib/hedwig_irc.ex
+++ b/lib/hedwig_irc.ex
@@ -91,6 +91,11 @@ defmodule Hedwig.Adapters.IRC do
     Logger.info "#{user} left with message: #{inspect message}"
     {:noreply, state}
   end
+  
+  def handle_info(:disconnected, state = {robot, _opts, _client}) do
+    Robot.handle_disconnect(robot, nil)
+    {:noreply, state}
+  end
 
   def handle_info(msg, state) do
     Logger.debug "Unknown message: #{inspect msg}"


### PR DESCRIPTION
I am using it with the Slack IRC Bridge and it sometimes sends a `:disconnected` message.
It also seems this adapter is missing something because it seems to ignore the reconnect message from Hedwig. More info here: https://github.com/hedwig-im/hedwig/issues/79